### PR TITLE
Add dynamic skill loader with Spotify and weather skills

### DIFF
--- a/core/modules/llm/router.py
+++ b/core/modules/llm/router.py
@@ -1,9 +1,16 @@
 from modules.llm.thinker import Thinker
 from modules.memory.memory import Memory
+from modules.skills import handle_prompt
 
 memory = Memory()
 
 def route_input(prompt: str) -> str:
+    # Check dynamic skills first
+    skill_response = handle_prompt(prompt)
+    if skill_response:
+        memory.log("skill_used", f"{prompt} -> {skill_response}")
+        return skill_response
+
     model = Thinker()
 
     try:

--- a/core/modules/skills/__init__.py
+++ b/core/modules/skills/__init__.py
@@ -1,0 +1,3 @@
+from .loader import handle_prompt, reload_skills
+
+__all__ = ['handle_prompt', 'reload_skills']

--- a/core/modules/skills/loader.py
+++ b/core/modules/skills/loader.py
@@ -1,0 +1,35 @@
+import os
+import importlib.util
+
+SKILL_DIR = os.path.dirname(__file__)
+
+_loaded_skills = []
+
+def _load_skills():
+    global _loaded_skills
+    _loaded_skills = []
+    for fname in os.listdir(SKILL_DIR):
+        if fname.endswith('.py') and fname not in ('__init__.py', 'loader.py'):
+            path = os.path.join(SKILL_DIR, fname)
+            spec = importlib.util.spec_from_file_location(fname[:-3], path)
+            if spec and spec.loader:
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                _loaded_skills.append(module)
+
+_load_skills()
+
+def reload_skills():
+    _load_skills()
+
+
+def handle_prompt(prompt: str):
+    for mod in _loaded_skills:
+        try:
+            can = getattr(mod, 'can_handle', None)
+            handle = getattr(mod, 'handle', None)
+            if callable(can) and can(prompt) and callable(handle):
+                return handle(prompt)
+        except Exception:
+            continue
+    return None

--- a/core/modules/skills/spotify_player.py
+++ b/core/modules/skills/spotify_player.py
@@ -1,0 +1,19 @@
+"""Simple Spotify music player skill placeholder."""
+
+import re
+
+_trigger = re.compile(r"play\s+(?P<song>.+)", re.IGNORECASE)
+
+
+def can_handle(prompt: str) -> bool:
+    return bool(_trigger.search(prompt))
+
+
+def handle(prompt: str) -> str:
+    match = _trigger.search(prompt)
+    if match:
+        song = match.group('song').strip()
+        song = re.sub(r'on spotify$', '', song, flags=re.IGNORECASE).strip()
+        if song:
+            return f"Playing {song} on Spotify."
+    return "Opening Spotify and playing your music."

--- a/core/modules/skills/weather_checker.py
+++ b/core/modules/skills/weather_checker.py
@@ -1,0 +1,23 @@
+"""Weather checking skill using wttr.in service."""
+
+import re
+import requests
+
+_pattern = re.compile(r"weather(?: in)? (?P<loc>[\w\s]+)?", re.IGNORECASE)
+
+
+def can_handle(prompt: str) -> bool:
+    return 'weather' in prompt.lower()
+
+
+def handle(prompt: str) -> str:
+    match = _pattern.search(prompt)
+    location = match.group('loc').strip() if match and match.group('loc') else ''
+    query = location if location else ''
+    try:
+        url = f'https://wttr.in/{query}?format=3'
+        r = requests.get(url, timeout=5)
+        r.raise_for_status()
+        return r.text.strip()
+    except Exception:
+        return "Unable to fetch weather right now."


### PR DESCRIPTION
## Summary
- add dynamic skill loader to load skills from `modules/skills`
- integrate skill check into LLM router
- implement spotify music player skill
- implement weather checker skill

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=core python - <<'PY'
from modules.skills import handle_prompt
print(handle_prompt('play Bohemian Rhapsody on Spotify'))
print(handle_prompt('weather in Paris'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6844300ac49083229ba71c1aed8f9f5d